### PR TITLE
feat: Agregar plantillas HTML e integrarlas al servidor HTTP (#6)

### DIFF
--- a/src/templates/login.html
+++ b/src/templates/login.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <title>Portal Cautivo - Iniciar sesión</title>
+    <style>
+        body { font-family: Arial, sans-serif; margin: 40px; }
+        .container { max-width: 400px; margin: auto; }
+        h1 { text-align: center; }
+        label { display: block; margin-top: 15px; }
+        input[type="text"], input[type="password"] {
+            width: 100%; padding: 8px; margin-top: 5px; 
+            border: 1px solid #ccc; border-radius: 4px;
+        }
+        button {
+            margin-top: 20px; padding: 10px; width: 100%;
+            background-color: #4caf50; color: white; 
+            border: none; border-radius: 4px; cursor: pointer;
+        }
+        button:hover { background-color: #45a049; }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <h1>Portal Cautivo</h1>
+        <form method="POST" action="/login">
+            <label>Usuario:</label>
+            <input type="text" name="username" required>
+
+            <label>Contraseña:</label>
+            <input type="password" name="password" required>
+
+            <button type="submit">Ingresar</button>
+        </form>
+    </div>
+</body>
+</html>

--- a/src/templates/login_error.html
+++ b/src/templates/login_error.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <title>Error de autenticación</title>
+    <style>
+        body { font-family: Arial, sans-serif; margin: 40px; text-align: center; }
+        p { color: #c0392b; font-size: 18px; }
+        a { display: inline-block; margin-top: 20px; color: #2980b9; }
+    </style>
+</head>
+<body>
+    <h1>Acceso denegado</h1>
+    <p>Usuario o contraseña incorrectos.</p>
+    <a href="/login">Intentar nuevamente</a>
+</body>
+</html>

--- a/src/templates/login_success.html
+++ b/src/templates/login_success.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <title>Acceso concedido</title>
+    <style>
+        body { font-family: Arial, sans-serif; margin: 40px; text-align: center; }
+        a { display: inline-block; margin-top: 20px; color: #4caf50; font-size: 18px; }
+    </style>
+</head>
+<body>
+    <h1>¡Autenticación exitosa!</h1>
+    <p>Ahora tienes acceso a Internet.</p>
+    <a href="/">Ir a la página principal</a>
+</body>
+</html>


### PR DESCRIPTION
### 🧩 Descripción
Este Pull Request implementa el Issue #6: creación e integración de las plantillas HTML básicas del portal cautivo.

Se agregaron las páginas:
- `login.html`: formulario de autenticación.
- `login_success.html`: mensaje de acceso exitoso.
- `login_error.html`: mensaje de error de autenticación.

Además, se integraron con el servidor HTTP manual implementado previamente (Issue #5).  
El servidor ahora puede servir estas plantillas a través de rutas GET:

- `/login` → muestra el formulario de login  
- `/success` → muestra la página de éxito  
- `/error` → muestra la página de error  
- `/` y `/index` → página principal (ya existente)

### ✅ Cambios principales
- Se añadieron las plantillas HTML al directorio `src/templates/`.
- Se implementó un sistema básico de enrutamiento por path en `handle_client()`.
- Se creó una caché de plantillas para mejorar rendimiento y organización.
- Se ajustó el servidor HTTP para retornar la plantilla correspondiente según la ruta solicitada.
- Mantenimiento general y logging adicional.

### 🧪 Pruebas manuales realizadas
1. Se levantó el servidor con:
python3 src/http_server.py
2. Se probó en el navegador:
- http://localhost:8080/login
- http://localhost:8080/success
- http://localhost:8080/error
- http://localhost:8080/noexiste (retorna 404 básico)
3. Todas las rutas respondieron con el HTML esperado.

### 📌 Resultado
El portal ahora cuenta con sus primeras vistas HTML funcionales y el servidor puede servirlas correctamente