### PR TITLE
feat: login POST: procesar credenciales y validar con auth (#8)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,4 +29,5 @@ config/sessions.json
 # Archivos temporales
 *.tmp
 *.bak
+__pycache__/
 *~


### PR DESCRIPTION
### Descripción
Implementa Issue #8: extensión del servidor HTTP para procesar el formulario de login vía POST.

### Cambios principales
- Carga de usuarios en memoria usando `src/auth.py`.
- Función `read_post_body_and_parse` para leer/parsear POST form-urlencoded.
- Extensión de `handle_client` para soportar `POST /login`:
  - valida campos vacíos
  - llama a `authenticate(username, password, USERS)`
  - muestra `login_success.html` o `login_error.html` según el resultado
- Logs informativos de intentos de login y errores.
- Manejo de errores robusto (content-length, lectura de socket, excepciones).

### Pruebas manuales
1. `python3 src/http_server.py`
2. `curl -i http://localhost:8080/login` (GET)
3. `curl -i -X POST -d "username=admin&password=admin" http://localhost:8080/login` (POST válido)
4. `curl -i -X POST -d "username=x&password=y" http://localhost:8080/login` (POST inválido)

Relacionado: Issue #8