### PR TITLE
feat: integrar login con firewall mediante creación de sesiones y reglas dinámicas (#10)

### DIFF
--- a/docs/firewall.md
+++ b/docs/firewall.md
@@ -42,3 +42,24 @@ En Debian/Ubuntu, instala el paquete `iptables-persistent` para que las reglas g
 sudo apt-get update
 sudo apt-get install iptables-persistent
 ```
+
+## Reglas dinámicas por cliente (login)
+
+Cuando un cliente se autentica exitosamente, el portal crea una sesión y añade una regla dinámica en la cadena FORWARD para permitir el enrutamiento desde la IP del cliente hacia Internet.
+
+Ejemplo de regla añadida:
+
+    iptables -I FORWARD 1 -s <IP_CLIENTE> -j ACCEPT
+
+- Se inserta en la posición 1 para darle prioridad.
+- Al cerrar la sesión (o expirar el TTL) se elimina la regla:
+
+    iptables -D FORWARD -s <IP_CLIENTE> -j ACCEPT
+
+Notas operativas:
+- Requiere que `scripts/firewall_init.sh` configure FORWARD en DROP por defecto.
+- El módulo `src/firewall_dynamic.py` es el encargado de añadir/retirar reglas dinámicas.
+- El proceso que modifica iptables debe ejecutarse con privilegios (root) o a través de un helper confiable.
+- Para depuración puedes listar las reglas FORWARD con:
+    sudo iptables -L FORWARD -n -v
+

--- a/src/firewall_dynamic.py
+++ b/src/firewall_dynamic.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+"""
+firewall_dynamic.py
+--------------------
+Este módulo añade y elimina reglas de iptables dinámicamente
+cuando un usuario inicia o cierra sesión en el portal cautivo.
+"""
+
+import subprocess
+import logging
+
+IPTABLES = "/usr/sbin/iptables"   # O usa `command -v iptables`
+
+def _run(cmd: list[str]) -> bool:
+    """Ejecuta un comando y devuelve True/False según éxito."""
+    try:
+        subprocess.run(cmd, check=True)
+        logging.info("[FIREWALL] Ejecutado: %s", " ".join(cmd))
+        return True
+    except subprocess.CalledProcessError as exc:
+        logging.error("[FIREWALL] Error al ejecutar '%s': %s",
+                      " ".join(cmd), exc)
+        return False
+
+
+def permitir_ip(ip: str) -> bool:
+    """
+    Permite a una IP reenviar tráfico hacia Internet.
+    Se inserta al inicio de FORWARD para prioridad.
+    """
+    cmd = [IPTABLES, "-I", "FORWARD", "1", "-s", ip, "-j", "ACCEPT"]
+    return _run(cmd)
+
+
+def denegar_ip(ip: str) -> bool:
+    """
+    Elimina la regla de FORWARD que permite a la IP navegar.
+    """
+    cmd = [IPTABLES, "-D", "FORWARD", "-s", ip, "-j", "ACCEPT"]
+    return _run(cmd)
+
+
+def listar_reglas() -> None:
+    """Imprime las reglas actuales (para debug)."""
+    subprocess.run([IPTABLES, "-L", "FORWARD", "-n", "-v"])


### PR DESCRIPTION
Este PR implementa todo el flujo necesario para permitir acceso a Internet solamente después de un login exitoso.

Cambios principales:
- sessions.py ahora llama a firewall_dynamic.permitir_ip() al crear una sesión.
- Cuando la sesión expira o se cierra, se llama a firewall_dynamic.denegar_ip().
- Se añadió lógica para revocar reglas cuando obtener_sesion() detecta expiración.
- Se agregaron logs de depuración útiles en ambos módulos.
- firewall_dynamic.py implementado para añadir y remover reglas iptables en FORWARD.


Este PR completa el Issue #10.
