### PR TITLE
feat: Implementar redireccion de portal cautivo (#21)

### DIFF
--- a/src/sessions.py
+++ b/src/sessions.py
@@ -337,9 +337,20 @@ def obtener_todas_las_sesiones() -> Dict[SessionKey, Session]:
     """
     with _lock:
         return dict(_sessions)
+    
+def is_authenticated(ip: str, mac: Optional[str] = None) -> bool:
+    """
+    Devuelve True si la IP (y opcionalmente la MAC) tiene una sesión activa.
+
+    Utiliza obtener_sesion, lo que garantiza que las sesiones expiradas
+    se limpien automáticamente.
+    """
+    return obtener_sesion(ip, mac) is not None
 
 # Restauramos sesiones (si existen en disco) al importar el módulo
 _load_from_disk()
+
+
 
 if __name__ == "__main__":
     # Restaura sesiones previas antes de iniciar pruebas manuales
@@ -363,3 +374,5 @@ if __name__ == "__main__":
     time.sleep(6)
     s3 = obtener_sesion("10.0.2.15", mac="aa:bb:cc:dd:ee:ff")
     print("Después de la expiración, obtener_sesion ->", s3)
+
+


### PR DESCRIPTION
## Descripción

Este Pull Request implementa la funcionalidad central del portal cautivo: **la redirección de clientes no autenticados a la página de login (`/login`)**.

### Cambios Clave

1.  **Manejo en `src/http_server.py`:**
    * Se implementó la lógica dentro de `handle_client` para verificar el estado de autenticación del cliente (por IP) usando `sessions.is_authenticated()`.
    * Si el cliente intenta acceder a cualquier ruta que no sea de servicio (`/login`, `/error`, `/success`) y no tiene una sesión activa, se responde con un **código HTTP 302 Found** y el encabezado `Location: /login`.

2.  **Manejo en `src/sessions.py`:**
    * Se añadió la función pública `is_authenticated(ip, mac=None)` que sirve como *interfaz* para el servidor HTTP. Esta función utiliza `obtener_sesion` para verificar si la IP tiene una sesión vigente, asegurando que las sesiones expiradas sean eliminadas automáticamente.

3.  **Lógica de Red de Sesiones:**
    * La verificación de la sesión se basa en la **IP del cliente**. (Si la lookup ARP es exitosa, la MAC también está en la sesión, mejorando el control, pero la IP sigue siendo la clave principal para la redirección inicial).

### Criterios de Aceptación

* [X] Al acceder a `/` o cualquier otra ruta sin estar autenticado, el cliente es redirigido a `/login`.
* [X] El módulo `sessions.py` provee un mecanismo thread-safe para la consulta de autenticación.
* [ ] (Prueba pendiente) Tras un login exitoso, `crear_sesion` añade la regla de firewall dinámico, permitiendo el tráfico de la IP.